### PR TITLE
Link to GitHub company profiles

### DIFF
--- a/src/helper/markdown/format_markdown.js
+++ b/src/helper/markdown/format_markdown.js
@@ -30,6 +30,8 @@ let formatMarkdown = function () {
     let getCompany = function (company) {
         if(company === 'undefined value'){
             return `No Company`;
+        } else if (company.startsWith('@')) {
+            return `<a href="https://github.com/${company.substring(1)}">${company}</a>`
         } else {
             return breakWords(company, 4)
         }


### PR DESCRIPTION
Link to GitHub orgs the same way GitHub profiles link to them if you mention an org GitHub username in the Company field.